### PR TITLE
Linked firefox-esr to firefox

### DIFF
--- a/usr/share/icons/Mint-Y/apps/16/firefox-esr.png
+++ b/usr/share/icons/Mint-Y/apps/16/firefox-esr.png
@@ -1,0 +1,1 @@
+firefox.png

--- a/usr/share/icons/Mint-Y/apps/22/firefox-esr.png
+++ b/usr/share/icons/Mint-Y/apps/22/firefox-esr.png
@@ -1,0 +1,1 @@
+firefox.png

--- a/usr/share/icons/Mint-Y/apps/24/firefox-esr.png
+++ b/usr/share/icons/Mint-Y/apps/24/firefox-esr.png
@@ -1,0 +1,1 @@
+firefox.png

--- a/usr/share/icons/Mint-Y/apps/256/firefox-esr.png
+++ b/usr/share/icons/Mint-Y/apps/256/firefox-esr.png
@@ -1,0 +1,1 @@
+firefox.png

--- a/usr/share/icons/Mint-Y/apps/32/firefox-esr.png
+++ b/usr/share/icons/Mint-Y/apps/32/firefox-esr.png
@@ -1,0 +1,1 @@
+firefox.png

--- a/usr/share/icons/Mint-Y/apps/48/firefox-esr.png
+++ b/usr/share/icons/Mint-Y/apps/48/firefox-esr.png
@@ -1,0 +1,1 @@
+firefox.png

--- a/usr/share/icons/Mint-Y/apps/64/firefox-esr.png
+++ b/usr/share/icons/Mint-Y/apps/64/firefox-esr.png
@@ -1,0 +1,1 @@
+firefox.png

--- a/usr/share/icons/Mint-Y/apps/96/firefox-esr.png
+++ b/usr/share/icons/Mint-Y/apps/96/firefox-esr.png
@@ -1,0 +1,1 @@
+firefox.png


### PR DESCRIPTION
Just adding/linking a firefox-esr icon to firefox.png. There wasn't a firefox-esr icon before so it got a really generic theme which didn't match the other mint-y icons.

Cheers!