### PR TITLE
Add link for new Skype for Linux icons.

### DIFF
--- a/usr/share/icons/Mint-Y/apps/16/skypeforlinux.png
+++ b/usr/share/icons/Mint-Y/apps/16/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-Y/apps/22/skypeforlinux.png
+++ b/usr/share/icons/Mint-Y/apps/22/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-Y/apps/24/skypeforlinux.png
+++ b/usr/share/icons/Mint-Y/apps/24/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-Y/apps/256/skypeforlinux.png
+++ b/usr/share/icons/Mint-Y/apps/256/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-Y/apps/32/skypeforlinux.png
+++ b/usr/share/icons/Mint-Y/apps/32/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-Y/apps/48/skypeforlinux.png
+++ b/usr/share/icons/Mint-Y/apps/48/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-Y/apps/64/skypeforlinux.png
+++ b/usr/share/icons/Mint-Y/apps/64/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png

--- a/usr/share/icons/Mint-Y/apps/96/skypeforlinux.png
+++ b/usr/share/icons/Mint-Y/apps/96/skypeforlinux.png
@@ -1,0 +1,1 @@
+skype.png


### PR DESCRIPTION
[mint-x-icons](https://github.com/linuxmint/mint-x-icons/pull/163) | **mint-y-icons**

The new Skype for Linux Beta uses `skypeforlinux` as the icon name instead of `skype`. This adds a symlink to customize its icon as well.