### PR TITLE
Link minecraft-launcher to minecraft

### DIFF
--- a/usr/share/icons/Mint-Y/apps/16/minecraft-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/16/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-Y/apps/22/minecraft-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/22/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-Y/apps/24/minecraft-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/24/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-Y/apps/256/minecraft-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/256/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-Y/apps/32/minecraft-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/32/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-Y/apps/48/minecraft-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/48/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-Y/apps/64/minecraft-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/64/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png

--- a/usr/share/icons/Mint-Y/apps/96/minecraft-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/96/minecraft-launcher.png
@@ -1,0 +1,1 @@
+minecraft.png


### PR DESCRIPTION
`minecraft-launcher` is used for the official Minecraft launcher package, which is currently in testing.