### PR TITLE
Add links for several icons used in Gnome and Cinnamon.

### DIFF
--- a/usr/share/icons/Mint-Y/apps/16/cinnamon-preferences-desktop-display.png
+++ b/usr/share/icons/Mint-Y/apps/16/cinnamon-preferences-desktop-display.png
@@ -1,0 +1,1 @@
+preferences-desktop-display.png

--- a/usr/share/icons/Mint-Y/apps/16/cinnamon-preferences-system-time.png
+++ b/usr/share/icons/Mint-Y/apps/16/cinnamon-preferences-system-time.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/16/gnome-panel-clock.png
+++ b/usr/share/icons/Mint-Y/apps/16/gnome-panel-clock.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/16/gnome-panel-hibernate.png
+++ b/usr/share/icons/Mint-Y/apps/16/gnome-panel-hibernate.png
@@ -1,0 +1,1 @@
+gnome-session-hibernate.png

--- a/usr/share/icons/Mint-Y/apps/16/gnome-panel-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/16/gnome-panel-launcher.png
@@ -1,0 +1,1 @@
+app-launcher.png

--- a/usr/share/icons/Mint-Y/apps/16/gnome-panel-notification-area.png
+++ b/usr/share/icons/Mint-Y/apps/16/gnome-panel-notification-area.png
@@ -1,0 +1,1 @@
+preferences-system-notifications.png

--- a/usr/share/icons/Mint-Y/apps/16/gnome-panel-suspend.png
+++ b/usr/share/icons/Mint-Y/apps/16/gnome-panel-suspend.png
@@ -1,0 +1,1 @@
+gnome-session-suspend.png

--- a/usr/share/icons/Mint-Y/apps/16/gnome-panel-window-list.png
+++ b/usr/share/icons/Mint-Y/apps/16/gnome-panel-window-list.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/16/gnome-panel-window-menu.png
+++ b/usr/share/icons/Mint-Y/apps/16/gnome-panel-window-menu.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/16/gnome-panel-workspace-switcher.png
+++ b/usr/share/icons/Mint-Y/apps/16/gnome-panel-workspace-switcher.png
@@ -1,0 +1,1 @@
+workspace-switcher-top-left.png

--- a/usr/share/icons/Mint-Y/apps/22/cinnamon-preferences-desktop-display.png
+++ b/usr/share/icons/Mint-Y/apps/22/cinnamon-preferences-desktop-display.png
@@ -1,0 +1,1 @@
+preferences-desktop-display.png

--- a/usr/share/icons/Mint-Y/apps/22/cinnamon-preferences-system-time.png
+++ b/usr/share/icons/Mint-Y/apps/22/cinnamon-preferences-system-time.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/22/gnome-panel-clock.png
+++ b/usr/share/icons/Mint-Y/apps/22/gnome-panel-clock.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/22/gnome-panel-hibernate.png
+++ b/usr/share/icons/Mint-Y/apps/22/gnome-panel-hibernate.png
@@ -1,0 +1,1 @@
+gnome-session-hibernate.png

--- a/usr/share/icons/Mint-Y/apps/22/gnome-panel-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/22/gnome-panel-launcher.png
@@ -1,0 +1,1 @@
+app-launcher.png

--- a/usr/share/icons/Mint-Y/apps/22/gnome-panel-notification-area.png
+++ b/usr/share/icons/Mint-Y/apps/22/gnome-panel-notification-area.png
@@ -1,0 +1,1 @@
+preferences-system-notifications.png

--- a/usr/share/icons/Mint-Y/apps/22/gnome-panel-suspend.png
+++ b/usr/share/icons/Mint-Y/apps/22/gnome-panel-suspend.png
@@ -1,0 +1,1 @@
+gnome-session-suspend.png

--- a/usr/share/icons/Mint-Y/apps/22/gnome-panel-window-list.png
+++ b/usr/share/icons/Mint-Y/apps/22/gnome-panel-window-list.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/22/gnome-panel-window-menu.png
+++ b/usr/share/icons/Mint-Y/apps/22/gnome-panel-window-menu.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/22/gnome-panel-workspace-switcher.png
+++ b/usr/share/icons/Mint-Y/apps/22/gnome-panel-workspace-switcher.png
@@ -1,0 +1,1 @@
+workspace-switcher-top-left.png

--- a/usr/share/icons/Mint-Y/apps/24/cinnamon-preferences-desktop-display.png
+++ b/usr/share/icons/Mint-Y/apps/24/cinnamon-preferences-desktop-display.png
@@ -1,0 +1,1 @@
+preferences-desktop-display.png

--- a/usr/share/icons/Mint-Y/apps/24/cinnamon-preferences-system-time.png
+++ b/usr/share/icons/Mint-Y/apps/24/cinnamon-preferences-system-time.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/24/gnome-panel-clock.png
+++ b/usr/share/icons/Mint-Y/apps/24/gnome-panel-clock.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/24/gnome-panel-hibernate.png
+++ b/usr/share/icons/Mint-Y/apps/24/gnome-panel-hibernate.png
@@ -1,0 +1,1 @@
+gnome-session-hibernate.png

--- a/usr/share/icons/Mint-Y/apps/24/gnome-panel-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/24/gnome-panel-launcher.png
@@ -1,0 +1,1 @@
+app-launcher.png

--- a/usr/share/icons/Mint-Y/apps/24/gnome-panel-notification-area.png
+++ b/usr/share/icons/Mint-Y/apps/24/gnome-panel-notification-area.png
@@ -1,0 +1,1 @@
+preferences-system-notifications.png

--- a/usr/share/icons/Mint-Y/apps/24/gnome-panel-suspend.png
+++ b/usr/share/icons/Mint-Y/apps/24/gnome-panel-suspend.png
@@ -1,0 +1,1 @@
+gnome-session-suspend.png

--- a/usr/share/icons/Mint-Y/apps/24/gnome-panel-window-list.png
+++ b/usr/share/icons/Mint-Y/apps/24/gnome-panel-window-list.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/24/gnome-panel-window-menu.png
+++ b/usr/share/icons/Mint-Y/apps/24/gnome-panel-window-menu.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/24/gnome-panel-workspace-switcher.png
+++ b/usr/share/icons/Mint-Y/apps/24/gnome-panel-workspace-switcher.png
@@ -1,0 +1,1 @@
+workspace-switcher-top-left.png

--- a/usr/share/icons/Mint-Y/apps/256/cinnamon-preferences-desktop-display.png
+++ b/usr/share/icons/Mint-Y/apps/256/cinnamon-preferences-desktop-display.png
@@ -1,0 +1,1 @@
+preferences-desktop-display.png

--- a/usr/share/icons/Mint-Y/apps/256/cinnamon-preferences-system-time.png
+++ b/usr/share/icons/Mint-Y/apps/256/cinnamon-preferences-system-time.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/256/gnome-panel-clock.png
+++ b/usr/share/icons/Mint-Y/apps/256/gnome-panel-clock.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/256/gnome-panel-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/256/gnome-panel-launcher.png
@@ -1,0 +1,1 @@
+app-launcher.png

--- a/usr/share/icons/Mint-Y/apps/256/gnome-panel-notification-area.png
+++ b/usr/share/icons/Mint-Y/apps/256/gnome-panel-notification-area.png
@@ -1,0 +1,1 @@
+preferences-system-notifications.png

--- a/usr/share/icons/Mint-Y/apps/256/gnome-panel-window-list.png
+++ b/usr/share/icons/Mint-Y/apps/256/gnome-panel-window-list.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/256/gnome-panel-window-menu.png
+++ b/usr/share/icons/Mint-Y/apps/256/gnome-panel-window-menu.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/256/gnome-panel-workspace-switcher.png
+++ b/usr/share/icons/Mint-Y/apps/256/gnome-panel-workspace-switcher.png
@@ -1,0 +1,1 @@
+workspace-switcher-top-left.png

--- a/usr/share/icons/Mint-Y/apps/32/cinnamon-preferences-desktop-display.png
+++ b/usr/share/icons/Mint-Y/apps/32/cinnamon-preferences-desktop-display.png
@@ -1,0 +1,1 @@
+preferences-desktop-display.png

--- a/usr/share/icons/Mint-Y/apps/32/cinnamon-preferences-system-time.png
+++ b/usr/share/icons/Mint-Y/apps/32/cinnamon-preferences-system-time.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/32/gnome-panel-clock.png
+++ b/usr/share/icons/Mint-Y/apps/32/gnome-panel-clock.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/32/gnome-panel-hibernate.png
+++ b/usr/share/icons/Mint-Y/apps/32/gnome-panel-hibernate.png
@@ -1,0 +1,1 @@
+gnome-session-hibernate.png

--- a/usr/share/icons/Mint-Y/apps/32/gnome-panel-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/32/gnome-panel-launcher.png
@@ -1,0 +1,1 @@
+app-launcher.png

--- a/usr/share/icons/Mint-Y/apps/32/gnome-panel-notification-area.png
+++ b/usr/share/icons/Mint-Y/apps/32/gnome-panel-notification-area.png
@@ -1,0 +1,1 @@
+preferences-system-notifications.png

--- a/usr/share/icons/Mint-Y/apps/32/gnome-panel-suspend.png
+++ b/usr/share/icons/Mint-Y/apps/32/gnome-panel-suspend.png
@@ -1,0 +1,1 @@
+gnome-session-suspend.png

--- a/usr/share/icons/Mint-Y/apps/32/gnome-panel-window-list.png
+++ b/usr/share/icons/Mint-Y/apps/32/gnome-panel-window-list.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/32/gnome-panel-window-menu.png
+++ b/usr/share/icons/Mint-Y/apps/32/gnome-panel-window-menu.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/32/gnome-panel-workspace-switcher.png
+++ b/usr/share/icons/Mint-Y/apps/32/gnome-panel-workspace-switcher.png
@@ -1,0 +1,1 @@
+workspace-switcher-top-left.png

--- a/usr/share/icons/Mint-Y/apps/48/cinnamon-preferences-desktop-display.png
+++ b/usr/share/icons/Mint-Y/apps/48/cinnamon-preferences-desktop-display.png
@@ -1,0 +1,1 @@
+preferences-desktop-display.png

--- a/usr/share/icons/Mint-Y/apps/48/cinnamon-preferences-system-time.png
+++ b/usr/share/icons/Mint-Y/apps/48/cinnamon-preferences-system-time.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/48/gnome-panel-clock.png
+++ b/usr/share/icons/Mint-Y/apps/48/gnome-panel-clock.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/48/gnome-panel-hibernate.png
+++ b/usr/share/icons/Mint-Y/apps/48/gnome-panel-hibernate.png
@@ -1,0 +1,1 @@
+gnome-session-hibernate.png

--- a/usr/share/icons/Mint-Y/apps/48/gnome-panel-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/48/gnome-panel-launcher.png
@@ -1,0 +1,1 @@
+app-launcher.png

--- a/usr/share/icons/Mint-Y/apps/48/gnome-panel-notification-area.png
+++ b/usr/share/icons/Mint-Y/apps/48/gnome-panel-notification-area.png
@@ -1,0 +1,1 @@
+preferences-system-notifications.png

--- a/usr/share/icons/Mint-Y/apps/48/gnome-panel-suspend.png
+++ b/usr/share/icons/Mint-Y/apps/48/gnome-panel-suspend.png
@@ -1,0 +1,1 @@
+gnome-session-suspend.png

--- a/usr/share/icons/Mint-Y/apps/48/gnome-panel-window-list.png
+++ b/usr/share/icons/Mint-Y/apps/48/gnome-panel-window-list.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/48/gnome-panel-window-menu.png
+++ b/usr/share/icons/Mint-Y/apps/48/gnome-panel-window-menu.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/48/gnome-panel-workspace-switcher.png
+++ b/usr/share/icons/Mint-Y/apps/48/gnome-panel-workspace-switcher.png
@@ -1,0 +1,1 @@
+workspace-switcher-top-left.png

--- a/usr/share/icons/Mint-Y/apps/64/cinnamon-preferences-desktop-display.png
+++ b/usr/share/icons/Mint-Y/apps/64/cinnamon-preferences-desktop-display.png
@@ -1,0 +1,1 @@
+preferences-desktop-display.png

--- a/usr/share/icons/Mint-Y/apps/64/cinnamon-preferences-system-time.png
+++ b/usr/share/icons/Mint-Y/apps/64/cinnamon-preferences-system-time.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/64/gnome-panel-clock.png
+++ b/usr/share/icons/Mint-Y/apps/64/gnome-panel-clock.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/64/gnome-panel-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/64/gnome-panel-launcher.png
@@ -1,0 +1,1 @@
+app-launcher.png

--- a/usr/share/icons/Mint-Y/apps/64/gnome-panel-notification-area.png
+++ b/usr/share/icons/Mint-Y/apps/64/gnome-panel-notification-area.png
@@ -1,0 +1,1 @@
+preferences-system-notifications.png

--- a/usr/share/icons/Mint-Y/apps/64/gnome-panel-window-list.png
+++ b/usr/share/icons/Mint-Y/apps/64/gnome-panel-window-list.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/64/gnome-panel-window-menu.png
+++ b/usr/share/icons/Mint-Y/apps/64/gnome-panel-window-menu.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/64/gnome-panel-workspace-switcher.png
+++ b/usr/share/icons/Mint-Y/apps/64/gnome-panel-workspace-switcher.png
@@ -1,0 +1,1 @@
+workspace-switcher-top-left.png

--- a/usr/share/icons/Mint-Y/apps/96/cinnamon-preferences-desktop-display.png
+++ b/usr/share/icons/Mint-Y/apps/96/cinnamon-preferences-desktop-display.png
@@ -1,0 +1,1 @@
+preferences-desktop-display.png

--- a/usr/share/icons/Mint-Y/apps/96/cinnamon-preferences-system-time.png
+++ b/usr/share/icons/Mint-Y/apps/96/cinnamon-preferences-system-time.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/96/gnome-panel-clock.png
+++ b/usr/share/icons/Mint-Y/apps/96/gnome-panel-clock.png
@@ -1,0 +1,1 @@
+preferences-system-time.png

--- a/usr/share/icons/Mint-Y/apps/96/gnome-panel-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/96/gnome-panel-launcher.png
@@ -1,0 +1,1 @@
+app-launcher.png

--- a/usr/share/icons/Mint-Y/apps/96/gnome-panel-notification-area.png
+++ b/usr/share/icons/Mint-Y/apps/96/gnome-panel-notification-area.png
@@ -1,0 +1,1 @@
+preferences-system-notifications.png

--- a/usr/share/icons/Mint-Y/apps/96/gnome-panel-window-list.png
+++ b/usr/share/icons/Mint-Y/apps/96/gnome-panel-window-list.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/96/gnome-panel-window-menu.png
+++ b/usr/share/icons/Mint-Y/apps/96/gnome-panel-window-menu.png
@@ -1,0 +1,1 @@
+preferences-system-windows.png

--- a/usr/share/icons/Mint-Y/apps/96/gnome-panel-workspace-switcher.png
+++ b/usr/share/icons/Mint-Y/apps/96/gnome-panel-workspace-switcher.png
@@ -1,0 +1,1 @@
+workspace-switcher-top-left.png


### PR DESCRIPTION
![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/preferences-desktop-display.png)
`cinnamon-preferences-desktop-display` to `preferences-desktop-display`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/preferences-system-time.png)
`cinnamon-preferences-system-time` to `preferences-system-time`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/preferences-system-time.png)
`gnome-panel-clock` to `preferences-system-time`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/gnome-session-hibernate.png)
`gnome-panel-hibernate` to `gnome-session-hibernate`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/app-launcher.png)
`gnome-panel-launcher` to `app-launcher`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/preferences-system-notifications.png)
`gnome-panel-notification-area` to `preferences-system-notifications`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/gnome-session-suspend.png)
`gnome-panel-suspend` to `gnome-session-suspend`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/preferences-system-windows.png)
`gnome-panel-window-list` to `preferences-system-windows`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/preferences-system-windows.png)
`gnome-panel-window-menu` to `preferences-system-windows`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/workspace-switcher-top-left.png)
`gnome-panel-workspace-switcher` to `workspace-switcher-top-left`