### PR TITLE
Add icons for mintupdate.

### DIFF
--- a/usr/share/icons/Mint-Y/apps/16/mintupdate-release-upgrade.png
+++ b/usr/share/icons/Mint-Y/apps/16/mintupdate-release-upgrade.png
@@ -1,0 +1,1 @@
+system-software-install.png

--- a/usr/share/icons/Mint-Y/apps/16/mintupdate.png
+++ b/usr/share/icons/Mint-Y/apps/16/mintupdate.png
@@ -1,0 +1,1 @@
+system-software-update.png

--- a/usr/share/icons/Mint-Y/apps/22/mintupdate-release-upgrade.png
+++ b/usr/share/icons/Mint-Y/apps/22/mintupdate-release-upgrade.png
@@ -1,0 +1,1 @@
+system-software-install.png

--- a/usr/share/icons/Mint-Y/apps/22/mintupdate.png
+++ b/usr/share/icons/Mint-Y/apps/22/mintupdate.png
@@ -1,0 +1,1 @@
+system-software-update.png

--- a/usr/share/icons/Mint-Y/apps/24/mintupdate-release-upgrade.png
+++ b/usr/share/icons/Mint-Y/apps/24/mintupdate-release-upgrade.png
@@ -1,0 +1,1 @@
+system-software-install.png

--- a/usr/share/icons/Mint-Y/apps/24/mintupdate.png
+++ b/usr/share/icons/Mint-Y/apps/24/mintupdate.png
@@ -1,0 +1,1 @@
+system-software-update.png

--- a/usr/share/icons/Mint-Y/apps/256/mintupdate-release-upgrade.png
+++ b/usr/share/icons/Mint-Y/apps/256/mintupdate-release-upgrade.png
@@ -1,0 +1,1 @@
+system-software-install.png

--- a/usr/share/icons/Mint-Y/apps/256/mintupdate.png
+++ b/usr/share/icons/Mint-Y/apps/256/mintupdate.png
@@ -1,0 +1,1 @@
+system-software-update.png

--- a/usr/share/icons/Mint-Y/apps/32/mintupdate-release-upgrade.png
+++ b/usr/share/icons/Mint-Y/apps/32/mintupdate-release-upgrade.png
@@ -1,0 +1,1 @@
+system-software-install.png

--- a/usr/share/icons/Mint-Y/apps/32/mintupdate.png
+++ b/usr/share/icons/Mint-Y/apps/32/mintupdate.png
@@ -1,0 +1,1 @@
+system-software-update.png

--- a/usr/share/icons/Mint-Y/apps/48/mintupdate-release-upgrade.png
+++ b/usr/share/icons/Mint-Y/apps/48/mintupdate-release-upgrade.png
@@ -1,0 +1,1 @@
+system-software-install.png

--- a/usr/share/icons/Mint-Y/apps/48/mintupdate.png
+++ b/usr/share/icons/Mint-Y/apps/48/mintupdate.png
@@ -1,0 +1,1 @@
+system-software-update.png

--- a/usr/share/icons/Mint-Y/apps/64/mintupdate-release-upgrade.png
+++ b/usr/share/icons/Mint-Y/apps/64/mintupdate-release-upgrade.png
@@ -1,0 +1,1 @@
+system-software-install.png

--- a/usr/share/icons/Mint-Y/apps/64/mintupdate.png
+++ b/usr/share/icons/Mint-Y/apps/64/mintupdate.png
@@ -1,0 +1,1 @@
+system-software-update.png

--- a/usr/share/icons/Mint-Y/apps/96/mintupdate-release-upgrade.png
+++ b/usr/share/icons/Mint-Y/apps/96/mintupdate-release-upgrade.png
@@ -1,0 +1,1 @@
+system-software-install.png

--- a/usr/share/icons/Mint-Y/apps/96/mintupdate.png
+++ b/usr/share/icons/Mint-Y/apps/96/mintupdate.png
@@ -1,0 +1,1 @@
+system-software-update.png


### PR DESCRIPTION
![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/system-software-update.png)
`mintupdate` to `system-software-update`

![](https://github.com/linuxmint/mint-y-icons/raw/master/usr/share/icons/Mint-Y/apps/32/system-software-install.png)
`mintupdate-release-upgrade` to `system-software-install`
(This appears on the menu option when upgrading Mint.)

This does not change the tray icons.