### PR TITLE
Fallback on Adwaita instead of Mint-X

### DIFF
--- a/usr/share/icons/Mint-Y/index.theme
+++ b/usr/share/icons/Mint-Y/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
 Name=Mint-Y
-Inherits=Mint-X,gnome,hicolor
+Inherits=Adwaita,gnome,hicolor
 Comment=Icon theme built for Linux Mint. Uses elements of Vibrancy and Moka.
 
 Directories=actions/16,apps/16,apps/16@2x,categories/16,categories/16@2x,panel/16,places/16,places/16@2x,actions/22,apps/22,apps/22@2x,categories/22,categories/22@2x,panel/22,places/22,places/22@2x,actions/24,apps/24,apps/24@2x,categories/24,categories/24@2x,panel/24,places/24,places/24@2x,actions/32,apps/32,apps/32@2x,categories/32,categories/32@2x,panel/32,places/32,places/32@2x,actions/48,apps/48,apps/48@2x,categories/48,categories/48@2x,panel/48,places/48,places/48@2x,actions/64,apps/64,apps/64@2x,categories/64,categories/64@2x,places/64,places/64@2x,actions/96,apps/96,apps/96@2x,categories/96,categories/96@2x,places/96,places/96@2x,places/128,places/128@2x,actions/256,apps/256,apps/256@2x,categories/256,categories/256@2x,places/symbolic


### PR DESCRIPTION
Mint-X just doesn't work with the Mint-Y themes. Falling back on Adwaita will
give us better full color icons that work with dark parts of theme. It gives
us a good starting point to know where we need to add more support in Mint-Y