### PR TITLE
Fix symlinks script, add symlink for gnome-power-stats

### DIFF
--- a/src/create-symbolic-link-from-list.py
+++ b/src/create-symbolic-link-from-list.py
@@ -25,11 +25,12 @@ def check_symbolic_links_list():
 
 def create_symbolic_link(target, symlink):
     for apps_pixel in os.listdir(APPS_DIR):
-        target_path = os.path.join(APPS_DIR, apps_pixel, target).rstrip()
-        symlink_path = os.path.join(APPS_DIR, apps_pixel, symlink).rstrip()
-        if not os.path.islink(symlink_path):
-            subprocess.call(['ln', '-s', '-r', target_path, symlink_path])
-            print(symlink_path + " created")
+        if apps_pixel != "symbolic":
+            target_path = os.path.join(APPS_DIR, apps_pixel, target).rstrip()
+            symlink_path = os.path.join(APPS_DIR, apps_pixel, symlink).rstrip()
+            if not os.path.islink(symlink_path):
+                subprocess.call(['ln', '-s', '-r', target_path, symlink_path])
+                print(symlink_path + " created")
 
 def delete_symbolic_links():
     subprocess.call(['find', APPS_DIR, '-type', 'l', '-delete'])

--- a/src/symbolic-apps-list
+++ b/src/symbolic-apps-list
@@ -301,6 +301,7 @@ gnome-documents.png <- org.gnome.Documents.png
 gnome-nettool.png <- nmap_icon.png
 gnome-photos.png <- org.gnome.Photos.png
 gnome-power-statistics.png <- mate-power-statistics.png
+gnome-power-statistics.png <- org.gnome.PowerStats.png
 gnome-quadrapassel.png <- org.gnome.quadrapassel.png
 gnome-quadrapassel.png <- quadrapassel.png
 gnome-screenshot.png <- applets-screenshooter.png
@@ -1173,3 +1174,4 @@ yast.png <- yast2.png
 zsnes.png <- com.snes9x.Snes9x.png
 zsnes.png <- snes9x-gtk.png
 zsnes.png <- snes9x.png
+

--- a/usr/share/icons/Mint-Y/apps/16/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/16/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/22/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/22/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/24/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/24/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/256/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/256/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/32/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/32/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/48/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/48/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/64/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/64/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/96/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/96/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.PowerStats.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.PowerStats.png
@@ -1,0 +1,1 @@
+gnome-power-statistics.png


### PR DESCRIPTION
ignore symbolic dir, when creating symbolic links