### PR TITLE
add several symbolics

### DIFF
--- a/usr/share/icons/Mint-Y/actions/symbolic/edit-copy-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/edit-copy-symbolic.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="edit-copy-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 3,1 C 3,1 2,1 2,2 V 11 C 2,11 2,12 3,12 H 4 V 3 H 12 V 2 C 12,1 11,1 11,1 Z M 6,4 C 6,4 5,4 5,5 V 15 C 5,16 6,16 6,16 H 14 C 14,16 15,16 15,15 V 5 C 15,4 14,4 14,4 Z M 7,6 H 13 V 14 H 7 Z"
+     id="path2" />
+</svg>

--- a/usr/share/icons/Mint-Y/actions/symbolic/edit-cut-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/edit-cut-symbolic.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="edit-cut-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 4.5,2 C 3.12,2 2,3.12 2,4.5 2,5.88 3.12,7 4.5,7 4.95,7 5.36,6.86 5.72,6.66 L 7.69,8.5 5.72,10.34 C 5.36,10.14 4.95,10 4.5,10 3.12,10 2,11.12 2,12.5 2,13.88 3.12,15 4.5,15 5.88,15 7,13.88 7,12.5 7,12.27 6.96,12.06 6.91,11.84 L 9.03,9.78 13.5,14 H 15 V 13 L 6.91,5.16 C 6.96,4.95 7,4.73 7,4.5 7,3.12 5.88,2 4.5,2 Z M 4.5,3.5 C 5.05,3.5 5.5,3.95 5.5,4.5 5.5,5.05 5.05,5.5 4.5,5.5 3.95,5.5 3.5,5.05 3.5,4.5 3.5,3.95 3.95,3.5 4.5,3.5 Z M 13.5,3 9.56,6.72 10.88,8 15,4 V 3 Z M 4.5,11.5 C 5.05,11.5 5.5,11.95 5.5,12.5 5.5,13.05 5.05,13.5 4.5,13.5 3.95,13.5 3.5,13.05 3.5,12.5 3.5,11.95 3.95,11.5 4.5,11.5 Z"
+     id="path2" />
+</svg>

--- a/usr/share/icons/Mint-Y/actions/symbolic/edit-find-replace-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/edit-find-replace-symbolic.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="edit-find-replace-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 6.5,1 C 3.47,1 1,3.47 1,6.5 1,7.74 1.4163,8.88 2.1094,9.8 L 3.543,8.36 C 3.2039,7.82 3,7.19 3,6.5 3,4.56 4.55,3 6.5,3 7.1897,3 7.8245,3.2 8.3633,3.54 L 9.8008,2.1 C 8.8759,1.41 7.7334,1 6.5,1 Z M 11.266,9.83 9.8398,11.25 13.43,14.84 14.84,13.4 Z"
+     id="path2" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,11.32 V 14 H 4.67 L 11.42,7.25 8.75,4.57 Z M 13.79,4.89 C 14.07,4.61 14.07,4.16 13.79,3.88 L 12.12,2.21 C 11.83,1.93 11.39,1.93 11.11,2.21 L 9.71,3.61 12.38,6.29 Z"
+     id="path4" />
+</svg>

--- a/usr/share/icons/Mint-Y/actions/symbolic/edit-find-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/edit-find-symbolic.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="edit-find-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 6.5,1 C 9.53,1 12.03,3.47 12.03,6.5 12.03,7.65 11.64,8.71 11.03,9.59 L 14.84,13.4 13.43,14.84 9.62,11.03 C 8.74,11.64 7.65,12 6.5,12 3.47,12 1,9.53 1,6.5 1,3.47 3.47,1 6.5,1 Z M 6.5,3 C 4.55,3 3,4.56 3,6.5 3,8.44 4.55,10 6.5,10 8.45,10 10,8.44 10,6.5 10,4.56 8.45,3 6.5,3 Z"
+     id="path2" />
+</svg>

--- a/usr/share/icons/Mint-Y/actions/symbolic/edit-paste-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/edit-paste-symbolic.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="edit-paste-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-0.50847458"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 8,0 C 6.9,0 6,0.9 6,2 H 3 C 2,2 2,3 2,3 V 14 C 2,15 3,15 3,15 H 13 C 13,15 14,15 14,14 V 3 C 14,2 13,2 13,2 H 10 C 10,1.86 10,1.72 9.97,1.59 9.78,0.68 8.97,0 8,0 Z M 8,1 C 8.41,1 8.75,1.27 8.91,1.62 8.96,1.74 9,1.86 9,2 9,2.55 8.55,3 8,3 7.45,3 7,2.55 7,2 7,1.45 7.45,1 8,1 Z M 4,4 H 5 V 5 H 11 V 4 H 12 V 13 H 4 Z"
+     id="path2" />
+</svg>

--- a/usr/share/icons/Mint-Y/actions/symbolic/go-home-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/go-home-symbolic.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   height="16"
+   sodipodi:docname="user-home-symbolic.svg"
+   width="16.000002">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:cy="8.4697431"
+     inkscape:current-layer="layer13"
+     inkscape:window-width="1920"
+     pagecolor="#555753"
+     showborder="true"
+     showguides="true"
+     inkscape:snap-nodes="true"
+     objecttolerance="10"
+     showgrid="true"
+     inkscape:object-nodes="true"
+     inkscape:pageshadow="2"
+     inkscape:guide-bbox="true"
+     inkscape:window-x="0"
+     inkscape:snap-bbox="true"
+     bordercolor="#666666"
+     id="namedview88"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:window-y="24"
+     gridtolerance="10"
+     inkscape:zoom="15.622585"
+     inkscape:window-height="1029"
+     borderopacity="1"
+     guidetolerance="10"
+     inkscape:cx="12.744369"
+     inkscape:bbox-paths="false"
+     inkscape:snap-grids="true"
+     inkscape:pageopacity="1"
+     inkscape:snap-to-guides="true">
+    <inkscape:grid
+       visible="true"
+       spacingx="1px"
+       type="xygrid"
+       spacingy="1px"
+       id="grid4866"
+       empspacing="2"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="status"
+     style="display:inline" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="devices" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer11"
+     inkscape:label="apps" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="actions" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer13"
+     inkscape:label="places">
+    <g
+       transform="translate(254.0002,-820)"
+       id="g40072"
+       inkscape:label="folder-remote" />
+    <path
+       style="fill:#bebebe;fill-opacity:1;stroke:none;display:inline"
+       d="M 8 1 L 0 9.03125 L 2 9.03125 L 2 15 L 13.9375 15 L 13.9375 9.0625 L 16 9.0625 L 13 6.03125 L 13 3 L 11 3 L 11 4.03125 L 8 1 z "
+       transform="translate(482,176)"
+       id="Symbol" />
+  </g>
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer14"
+     inkscape:label="mimetypes" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer15"
+     inkscape:label="emblems"
+     style="display:inline" />
+</svg>

--- a/usr/share/icons/Mint-Y/actions/symbolic/xapp-go-history-next-symbolic-rtl.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/xapp-go-history-next-symbolic-rtl.svg
@@ -1,0 +1,1 @@
+xapp-go-history-previous-symbolic.svg

--- a/usr/share/icons/Mint-Y/actions/symbolic/xapp-go-history-next-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/xapp-go-history-next-symbolic.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   version="1.1"
+   width="16"
+   enable-background="new"
+   id="svg10"
+   sodipodi:docname="xapp-go-history-next-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="993"
+     inkscape:window-height="720"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="16.347772"
+     inkscape:cy="6.9209786"
+     inkscape:window-x="285"
+     inkscape:window-y="26"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer12">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4526" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="actions"
+     transform="translate(-261.00018,-29)">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 268.00018,30.96875 -1.40625,1.375 3.65625,3.65625 -8.25,-0.0313 v 2 l 8.25,0.03125 -3.65625,3.625 1.40625,1.375 6,-6.03125 -6,-6 z"
+       id="path5849"
+       style="fill:#bebebe;fill-opacity:1"
+       sodipodi:nodetypes="ccccccccccc" />
+    <g
+       id="g838"
+       transform="translate(-1.0000031,-8)">
+      <rect
+         id="rect20747"
+         x="276.00018"
+         y="40"
+         width="2"
+         height="2"
+         rx="0.38462001"
+         ry="0.37878999"
+         style="color:#000000;fill:#bebebe;enable-background:new" />
+      <rect
+         id="rect20749"
+         x="276.00018"
+         y="44.02002"
+         width="2"
+         height="2"
+         rx="0.38462001"
+         ry="0.37878999"
+         style="color:#000000;fill:#bebebe;enable-background:new" />
+      <rect
+         id="rect20751"
+         x="276.00018"
+         y="48"
+         width="2"
+         height="2"
+         rx="0.38462001"
+         ry="0.37878999"
+         style="color:#000000;fill:#bebebe;enable-background:new" />
+    </g>
+  </g>
+</svg>

--- a/usr/share/icons/Mint-Y/actions/symbolic/xapp-go-history-previous-symbolic-rtl.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/xapp-go-history-previous-symbolic-rtl.svg
@@ -1,0 +1,1 @@
+xapp-go-history-next-symbolic.svg

--- a/usr/share/icons/Mint-Y/actions/symbolic/xapp-go-history-previous-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/xapp-go-history-previous-symbolic.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   version="1.1"
+   width="16"
+   enable-background="new"
+   id="svg10"
+   sodipodi:docname="xapp-go-history-previous-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="993"
+     inkscape:window-height="720"
+     id="namedview12"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="1.8072488"
+     inkscape:cy="6.9190294"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer12">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4526" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs7386">
+    <linearGradient
+       id="linearGradient5606"
+       osb:paint="solid">
+      <stop
+         id="stop5608" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="actions"
+     transform="translate(-261.00018,-29)">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 270.00018,31.00005 1.40625,1.375 -3.65625,3.65625 8.25,-0.0313 v 2 l -8.25,0.03125 3.65625,3.625 -1.40625,1.375 -6,-6.03125 6,-6 z"
+       id="path5849"
+       style="fill:#bebebe;fill-opacity:1"
+       sodipodi:nodetypes="ccccccccccc" />
+    <g
+       id="g849"
+       transform="translate(4.9999969,-1)">
+      <rect
+         id="rect20747"
+         x="256.00018"
+         y="33"
+         width="2"
+         height="2"
+         rx="0.38462001"
+         ry="0.37878999"
+         style="color:#000000;fill:#bebebe;enable-background:new" />
+      <rect
+         id="rect20749"
+         x="256.00018"
+         y="37.02002"
+         width="2"
+         height="2"
+         rx="0.38462001"
+         ry="0.37878999"
+         style="color:#000000;fill:#bebebe;enable-background:new" />
+      <rect
+         id="rect20751"
+         x="256.00018"
+         y="41"
+         width="2"
+         height="2"
+         rx="0.38462001"
+         ry="0.37878999"
+         style="color:#000000;fill:#bebebe;enable-background:new" />
+    </g>
+  </g>
+</svg>

--- a/usr/share/icons/Mint-Y/apps/symbolic/preferences-desktop-display-symbolic.svg
+++ b/usr/share/icons/Mint-Y/apps/symbolic/preferences-desktop-display-symbolic.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="preferences-desktop-display-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="737"
+     inkscape:window-height="480"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 0,3 V 10 H 12 Z M 2,6 5,8 H 2 Z"
+     id="path2" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,0 C 0,0 0,2 0,2 H 14 V 11 H 0 C 0,11 0,13 2,13 H 14 C 14,13 16,13 16,11 V 2 C 16,2 16,0 14,0 Z M 4,14 C 4,14 3,14 3,15 V 16 H 13 V 15 C 13,14 12,14 12,14 Z"
+     id="path4" />
+</svg>

--- a/usr/share/icons/Mint-Y/apps/symbolic/preferences-desktop-remote-desktop-symbolic.svg
+++ b/usr/share/icons/Mint-Y/apps/symbolic/preferences-desktop-remote-desktop-symbolic.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="preferences-desktop-remote-desktop-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="737"
+     inkscape:window-height="480"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 3.5,5 C 3.5,5 3,5 3,5.5 V 9.5 C 3,10 3.5,10 3.5,10 H 7.5 C 8,10 8,9.5 8,9.5 V 5.5 C 8,5 7.56,5 7.5,5 Z M 4,7 H 7 V 9 H 4 Z"
+     id="path2" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,0 C 0,0 0,2 0,2 V 11 C 0,11 0,13 2,13 H 14 C 14,13 16,13 16,11 V 2 C 16,2 16,0 14,0 Z M 2,2 H 14 V 11 H 2 Z M 3,15 V 16 H 13 V 15 C 13,14 12,14 12,14 H 4 C 4,14 3,14 3,15 Z"
+     id="path4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 9.5,3 H 11.5 C 11.777,3 12,3.223 12,3.5 V 5.5 C 12,5.777 11.777,6 11.5,6 H 9.5 C 9.223,6 9,5.777 9,5.5 V 3.5 C 9,3.223 9.223,3 9.5,3 Z"
+     id="path6" />
+</svg>

--- a/usr/share/icons/Mint-Y/apps/symbolic/preferences-desktop-screensaver-symbolic.svg
+++ b/usr/share/icons/Mint-Y/apps/symbolic/preferences-desktop-screensaver-symbolic.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg16"
+   sodipodi:docname="preferences-desktop-screensaver-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs20" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="737"
+     inkscape:window-height="480"
+     id="namedview18"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8.5791729"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg16" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 10.48,4.69 C 10.8,5.08 11,5.58 11,6.12 11,7.37 9.99,8.38 8.74,8.38 8.2,8.38 7.7,8.18 7.31,7.86 7.59,9.02 8.63,9.88 9.87,9.88 11.32,9.88 12.5,8.7 12.5,7.25 12.5,6.01 11.64,4.96 10.48,4.69 Z"
+     id="path2" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 5.5,7.5 5,6 3.5,5.5 5,5 5.5,3.5 6,5 7.5,5.5 6,6 Z"
+     id="path4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,0 C 0,0 0,2 0,2 V 11 C 0,11 0,13 2,13 H 14 C 14,13 16,13 16,11 V 2 C 16,2 16,0 14,0 Z M 2,2 H 14 V 11 H 2 Z M 3,15 V 16 H 13 V 15 C 13,14 12,14 12,14 H 4 C 4,14 3,14 3,15 Z"
+     id="path6" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 8,3.5 A 0.5,0.5 0 0 1 7.5,4 0.5,0.5 0 0 1 7,3.5 0.5,0.5 0 0 1 7.5,3 0.5,0.5 0 0 1 8,3.5 Z"
+     id="path8" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 13,3.5 A 0.5,0.5 0 0 1 12.5,4 0.5,0.5 0 0 1 12,3.5 0.5,0.5 0 0 1 12.5,3 0.5,0.5 0 0 1 13,3.5 Z"
+     id="path10" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 9,5.5 A 0.5,0.5 0 0 1 8.5,6 0.5,0.5 0 0 1 8,5.5 0.5,0.5 0 0 1 8.5,5 0.5,0.5 0 0 1 9,5.5 Z"
+     id="path12" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 5,8.5 A 0.5,0.5 0 0 1 4.5,9 0.5,0.5 0 0 1 4,8.5 0.5,0.5 0 0 1 4.5,8 0.5,0.5 0 0 1 5,8.5 Z"
+     id="path14" />
+</svg>

--- a/usr/share/icons/Mint-Y/apps/symbolic/preferences-desktop-wallpaper-symbolic.svg
+++ b/usr/share/icons/Mint-Y/apps/symbolic/preferences-desktop-wallpaper-symbolic.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="preferences-desktop-wallpaper-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="737"
+     inkscape:window-height="480"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <path
+     style="opacity:0.3;fill:#bebebe;fill-opacity:1"
+     d="M 7,3 V 8 H 3 V 10 H 13 V 3 Z"
+     id="path2" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 6,3 3,7 H 6 Z"
+     id="path4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,0 C 0,0 0,2 0,2 V 11 C 0,11 0,13 2,13 H 14 C 14,13 16,13 16,11 V 2 C 16,2 16,0 14,0 Z M 2,2 H 14 V 11 H 2 Z M 3,15 V 16 H 13 V 15 C 13,14 12,14 12,14 H 4 C 4,14 3,14 3,15 Z"
+     id="path6" />
+</svg>

--- a/usr/share/icons/Mint-Y/devices/symbolic/computer-symbolic.svg
+++ b/usr/share/icons/Mint-Y/devices/symbolic/computer-symbolic.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="computer-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 15,1 C 16,1 16,2 16,2 V 12 C 16,12 16,13 15,13 H 1 C 1,13 0,13 0,12 V 2 C 0,2 0,1 1,1 Z M 14,3 H 2 V 11 H 14 Z M 11,14 V 15 H 5 V 14 C 5,13 6,13 6,13 H 10 C 10,13 11,13 11,14 Z"
+     id="path2" />
+</svg>

--- a/usr/share/icons/Mint-Y/devices/symbolic/media-flash-symbolic.svg
+++ b/usr/share/icons/Mint-Y/devices/symbolic/media-flash-symbolic.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="media-flash-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="745"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,14 C 2,15 3,15 3,15 H 5 V 14 H 11 V 15 H 13 C 14,15 14,14 14,14 V 2 C 14,1 13,1 13,1 H 6 L 2,5 Z M 7,3 H 8 V 6 H 7 Z M 9,3 H 10 V 6 H 9 Z M 11,3 H 12 V 6 H 11 Z M 5,4 H 6 V 6 H 5 Z"
+     id="path2" />
+</svg>

--- a/usr/share/icons/Mint-Y/devices/symbolic/media-floppy-symbolic.svg
+++ b/usr/share/icons/Mint-Y/devices/symbolic/media-floppy-symbolic.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="media-floppy-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="745"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,1 C 1.45,1 1,1.45 1,2 V 13 L 3,15 H 14 C 14.55,15 15,14.55 15,14 V 2 C 15,1.45 14.55,1 14,1 Z M 3,3 H 13 V 13 H 12 V 8 H 4 V 13 H 3 Z M 8,9 H 10 V 13 H 8 Z"
+     id="path2" />
+</svg>

--- a/usr/share/icons/Mint-Y/devices/symbolic/media-removable-symbolic.svg
+++ b/usr/share/icons/Mint-Y/devices/symbolic/media-removable-symbolic.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="media-removable-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     id="namedview6"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="7.812577"
+     inkscape:cy="8.3598054"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 5,16 C 5,16 4,16 4,15 V 6 C 4,6 4,5 5,5 h 6 c 1,0 1,1 1,1 v 9 c 0,1 -1,1 -1,1 z"
+     id="path2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cscsscscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#bebebe"
+     d="m 5,0 v 4 h 6 V 0 Z m 0.99998,1 h 1 v 1 h -1 z m 3,0 h 1 v 1 h -1 z"
+     id="rect9466" />
+</svg>

--- a/usr/share/icons/Mint-Y/devices/symbolic/phone-symbolic.svg
+++ b/usr/share/icons/Mint-Y/devices/symbolic/phone-symbolic.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16px"
+   height="16px"
+   id="svg3838"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="phone-symbolic.svg">
+  <defs
+     id="defs3840" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.197802"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="453"
+     inkscape:window-height="430"
+     inkscape:window-x="0"
+     inkscape:window-y="46"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata3843">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:0.99999982;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 5,0 C 3.892,0 3,0.892 3,2 l 0,12 c 0,1.108 0.892,2 2,2 l 6,0 c 1.108,0 2,-0.892 2,-2 L 13,2 C 13,0.892 12.108,0 11,0 L 5,0 z m -0.5,3 7,0 C 11.777,3 12,3.223 12,3.5 l 0,9 c 0,0.277 -0.223,0.5 -0.5,0.5 l -7,0 C 4.223,13 4,12.777 4,12.5 l 0,-9 C 4,3.223 4.223,3 4.5,3 z M 8,13.75 c 0.4142136,0 0.75,0.335786 0.75,0.75 0,0.414214 -0.3357864,0.75 -0.75,0.75 -0.4142136,0 -0.75,-0.335786 -0.75,-0.75 0,-0.414214 0.3357864,-0.75 0.75,-0.75 z"
+       id="rect3015" />
+  </g>
+</svg>

--- a/usr/share/icons/Mint-Y/devices/symbolic/video-display-symbolic.svg
+++ b/usr/share/icons/Mint-Y/devices/symbolic/video-display-symbolic.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="video-display-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="737"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,0 C 0,0 0,2 0,2 V 11 C 0,11 0,13 2,13 H 14 C 14,13 16,13 16,11 V 2 C 16,2 16,0 14,0 Z M 2,2 H 14 V 11 H 2 Z M 3,15 V 16 H 13 V 15 C 13,14 12,14 12,14 H 4 C 4,14 3,14 3,15 Z"
+     id="path2" />
+</svg>

--- a/usr/share/icons/Mint-Y/index.theme
+++ b/usr/share/icons/Mint-Y/index.theme
@@ -3,7 +3,7 @@ Name=Mint-Y
 Inherits=Adwaita,gnome,hicolor
 Comment=Icon theme built for Linux Mint. Uses elements of Vibrancy and Moka.
 
-Directories=actions/16,apps/16,apps/16@2x,categories/16,categories/16@2x,panel/16,places/16,places/16@2x,status/16,status/16@2x,actions/22,apps/22,apps/22@2x,categories/22,categories/22@2x,panel/22,places/22,places/22@2x,status/22,status/22@2x,actions/24,apps/24,apps/24@2x,categories/24,categories/24@2x,panel/24,places/24,places/24@2x,status/24,status/24@2x,actions/32,apps/32,apps/32@2x,categories/32,categories/32@2x,panel/32,places/32,places/32@2x,status/32,status/32@2x,actions/48,apps/48,apps/48@2x,categories/48,categories/48@2x,panel/48,places/48,places/48@2x,status/48,status/48@2x,actions/64,apps/64,apps/64@2x,categories/64,categories/64@2x,places/64,places/64@2x,status/64,status/64@2x,actions/96,apps/96,apps/96@2x,categories/96,categories/96@2x,places/96,places/96@2x,status/96,status/96@2x,places/128,places/128@2x,status/128,status/128@2x,actions/256,apps/256,apps/256@2x,categories/256,categories/256@2x,actions/symbolic,apps/symbolic,devices/symbolic,places/symbolic,status/symbolic
+Directories=actions/16,apps/16,apps/16@2x,categories/16,categories/16@2x,panel/16,places/16,places/16@2x,status/16,status/16@2x,actions/22,apps/22,apps/22@2x,categories/22,categories/22@2x,panel/22,places/22,places/22@2x,status/22,status/22@2x,actions/24,apps/24,apps/24@2x,categories/24,categories/24@2x,panel/24,places/24,places/24@2x,status/24,status/24@2x,actions/32,apps/32,apps/32@2x,categories/32,categories/32@2x,panel/32,places/32,places/32@2x,status/32,status/32@2x,actions/48,apps/48,apps/48@2x,categories/48,categories/48@2x,panel/48,places/48,places/48@2x,status/48,status/48@2x,actions/64,apps/64,apps/64@2x,categories/64,categories/64@2x,places/64,places/64@2x,status/64,status/64@2x,actions/96,apps/96,apps/96@2x,categories/96,categories/96@2x,places/96,places/96@2x,status/96,status/96@2x,places/128,places/128@2x,status/128,status/128@2x,actions/256,apps/256,apps/256@2x,categories/256,categories/256@2x,actions/symbolic,apps/symbolic,devices/symbolic,mimetypes/symbolic,places/symbolic,status/symbolic
 
 [actions/16]
 Size=16
@@ -244,6 +244,15 @@ Type=Fixed
 [devices/symbolic]
 Size=16
 Context=Devices
+Type=Scalable
+MinSize=16
+MaxSize=256
+
+###################
+
+[mimetypes/symbolic]
+Size=16
+Context=Mimetypes
 Type=Scalable
 MinSize=16
 MaxSize=256

--- a/usr/share/icons/Mint-Y/mimetypes/symbolic/audio-x-generic-symbolic.svg
+++ b/usr/share/icons/Mint-Y/mimetypes/symbolic/audio-x-generic-symbolic.svg
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   height="16"
+   sodipodi:docname="audio-x-generic-symbolic.svg"
+   width="16.000002">
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:cy="4.4630467"
+     inkscape:current-layer="layer13"
+     inkscape:window-width="1280"
+     pagecolor="#555753"
+     showborder="true"
+     showguides="false"
+     inkscape:snap-nodes="true"
+     objecttolerance="10"
+     showgrid="true"
+     inkscape:object-nodes="true"
+     inkscape:pageshadow="2"
+     inkscape:guide-bbox="true"
+     inkscape:window-x="0"
+     inkscape:snap-bbox="true"
+     bordercolor="#666666"
+     id="namedview88"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:window-y="0"
+     gridtolerance="10"
+     inkscape:zoom="22.627416"
+     inkscape:window-height="746"
+     borderopacity="1"
+     guidetolerance="10"
+     inkscape:cx="4.5603471"
+     inkscape:bbox-paths="true"
+     inkscape:snap-grids="true"
+     inkscape:pageopacity="1"
+     inkscape:snap-to-guides="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:lockguides="true">
+    <inkscape:grid
+       visible="true"
+       spacingx="1px"
+       type="xygrid"
+       spacingy="1px"
+       id="grid4866"
+       empspacing="2"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <defs
+     id="defs7386" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer9"
+     inkscape:label="status"
+     style="display:inline" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer10"
+     inkscape:label="devices" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer11"
+     inkscape:label="apps" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer12"
+     inkscape:label="actions" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer13"
+     inkscape:label="places">
+    <g
+       transform="translate(254.0002,-820)"
+       id="g40072"
+       inkscape:label="folder-remote" />
+    <path
+       style="display:inline;opacity:1;fill:#bebebe;fill-opacity:1;stroke:#4b4b4b;stroke-width:0;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 487,178 v 0.97461 1.02539 1 6.40234 A 2.5,2 0 0 0 485.5,187 a 2.5,2 0 0 0 -2.5,2 2.5,2 0 0 0 2.5,2 2.5,2 0 0 0 2.5,-2 v -8 h 7 v 5.40234 A 2.5,2 0 0 0 493.5,186 a 2.5,2 0 0 0 -2.5,2 2.5,2 0 0 0 2.5,2 2.5,2 0 0 0 2.5,-2 v -7 -1 -2 h -0.90039 z"
+       id="rect4067-4-5"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer14"
+     inkscape:label="mimetypes" />
+  <g
+     transform="translate(-482,-176)"
+     inkscape:groupmode="layer"
+     id="layer15"
+     inkscape:label="emblems"
+     style="display:inline" />
+</svg>

--- a/usr/share/icons/Mint-Y/status/symbolic/computer-fail-symbolic.svg
+++ b/usr/share/icons/Mint-Y/status/symbolic/computer-fail-symbolic.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="computer-fail-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="737"
+     inkscape:window-height="480"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 2,0 C 0,0 0,2 0,2 V 11 C 0,11 0,13 2,13 H 14 C 14,13 16,13 16,11 V 2 C 16,2 16,0 14,0 Z M 2,2 H 14 V 10 H 2 Z M 3,15 V 16 H 13 V 15 C 13,14 12,14 12,14 H 4 C 4,14 3,14 3,15 Z"
+     id="path2" />
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 5,3 V 5 H 6 V 3 Z M 10,3 V 5 H 11 V 3 Z M 5,7 V 8 H 11 V 7 Z M 11,8 V 9 H 12 V 8 Z M 5,8 H 4 V 9 H 5 Z"
+     id="path4" />
+</svg>

--- a/usr/share/icons/Mint-Y/status/symbolic/dialog-password-symbolic.svg
+++ b/usr/share/icons/Mint-Y/status/symbolic/dialog-password-symbolic.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="dialog-password-symbolic.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="746"
+     id="namedview8"
+     showgrid="true"
+     inkscape:zoom="20.85965"
+     inkscape:cx="2.2433757"
+     inkscape:cy="4.5688018"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6">
+    <inkscape:grid
+       type="xygrid"
+       id="grid816" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#bebebe;fill-opacity:1"
+     d="M 4.5,3 C 2.01,3 0,5.02 0,7.5 0,9.99 2.01,12 4.5,12 6.4,12 8.1,10.8 8.74,9 H 12 v 2 h 3 V 9 h 1 V 6 H 8.74 C 8.1,4.21 6.4,3.01 4.5,3 Z m 0,3 C 5.33,6 6,6.68 6,7.5 6,8.33 5.33,9 4.5,9 3.67,9 3,8.33 3,7.5 3,6.68 3.67,6 4.5,6 Z"
+     id="path2"
+     inkscape:connector-curvature="0" />
+</svg>


### PR DESCRIPTION
Most icons are from the Paper icon theme, except

phone is from Obsidian icon theme

go-history are based on the go-first/go-last icons, which were already
there

audio-x-generic is the same as the folder-music

the usb-icon is a mix of the Papirus version and the Adwaita version