### PR TITLE
Fix GNOME Screen Recorder Icon

### DIFF
--- a/src/symbolic-apps-list
+++ b/src/symbolic-apps-list
@@ -320,6 +320,7 @@ gnome-screenshot.png <- org.gnome.Screenshot.png
 gnome-screenshot.png <- simplescreenrecorder.png
 gnome-software.png <- org.gnome.Software.png
 gnome-sound-recorder.png <- audio-recorder.png
+gnome-sound-recorder.png <- org.gnome.SoundRecorder.png
 gnome-sound-recorder.png <- sound-recorder.png
 gnome-tali.png <- gnubg.png
 gnome-tali.png <- tali.png

--- a/usr/share/icons/Mint-Y/apps/16/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/16/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/22/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/22/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/24/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/24/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/256/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/256/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/32/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/32/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/48/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/48/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/64/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/64/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/96/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/96/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.SoundRecorder.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.SoundRecorder.png
@@ -1,0 +1,1 @@
+gnome-sound-recorder.png


### PR DESCRIPTION
GNOME Screen recorder icon name changed. Fix #265 
I have verified that it works.
![icon works](https://user-images.githubusercontent.com/3063132/97960918-515b2000-1dd8-11eb-9f90-af74c204c94a.png)