### PR TITLE
Fix Evince icon name

### DIFF
--- a/src/symbolic-apps-list
+++ b/src/symbolic-apps-list
@@ -242,6 +242,7 @@ emule.png <- amule.png
 espeak.png <- espeak-gui.png
 eufloria.png <- eufloriahd.png
 eufloria.png <- steam_icon_41210.png
+evince.png <- org.gnome.Evince.png
 extensions.png <- 67EF_addoninstaller.0.png
 extensions.png <- gnome-shell-extension-prefs.png
 fedora-utils.png <- fedorautils.png

--- a/usr/share/icons/Mint-Y/apps/16/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/16/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/22/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/22/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/24/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/24/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/256/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/256/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/32/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/32/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/48/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/48/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/64/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/64/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/96/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/96/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.Evince.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.Evince.png
@@ -1,0 +1,1 @@
+evince.png


### PR DESCRIPTION
Following other GNOME apps, the document reader `evince` changed its icon name to `org.gnome.Evince`. I have symlinked, and tested that it works.