### PR TITLE
[WIP] Verbose Output and Looser SVG Parsing

### DIFF
--- a/src/render-apps-categories-bitmaps.py
+++ b/src/render-apps-categories-bitmaps.py
@@ -35,6 +35,7 @@ assert (os.path.isdir(MAINDIR)), "Expected to find Mint-Y at ../usr/share/icons/
 # the resolution that non-hi-dpi icons are rendered at (may be 90 or 96 depending on your inkscape build)
 inkscape_version = str(subprocess.check_output(['inkscape', '-V'])).split(' ')[1].split('.')
 inkscape_version = float(inkscape_version[0] + '.' + inkscape_version[1])
+assert (inkscape_version < 1.0), "Expected Inkscape version lower than 1.0. This script doesn't work with Inkscape version 1.0 or higher. This will be changed in the future." 
 if inkscape_version < 0.92: # inkscape version 0.92 changed the default dpi from 90 to 96
     DPI_1_TO_1 = 90
 else:

--- a/src/render-apps-categories-bitmaps.py
+++ b/src/render-apps-categories-bitmaps.py
@@ -195,7 +195,7 @@ def main(args, SRC):
                             # If SVG is newer than PNG, replace PNG with updated version
                             if stat_in.st_mtime > stat_out.st_mtime:
                                 inkscape_render_rect(self.path, id, dpi, outfile)
-                                if args.VERBOSE:
+                                if args.verbose:
                                     print("├─ Rendered updated \"".decode('utf-8') + outfile + "\"")
                                 # print("Rendered updated " + outfile)
                                 updated_renders += 1

--- a/src/render-apps-categories-bitmaps.py
+++ b/src/render-apps-categories-bitmaps.py
@@ -183,7 +183,8 @@ def main(args, SRC):
                         # If PNG does not exist, create it new
                         if self.force or not os.path.exists(outfile):
                             inkscape_render_rect(self.path, id, dpi, outfile)
-                            print("├─ Rendered new \"".decode('utf-8') + outfile + "\"")
+                            if args.verbose:
+                                print("├─ Rendered new \"".decode('utf-8') + outfile + "\"")
                             new_renders += 1
 
                         # If PNG exists, compare modify time to that of SVG
@@ -194,15 +195,18 @@ def main(args, SRC):
                             # If SVG is newer than PNG, replace PNG with updated version
                             if stat_in.st_mtime > stat_out.st_mtime:
                                 inkscape_render_rect(self.path, id, dpi, outfile)
-                                print("├─ Rendered updated \"".decode('utf-8') + outfile + "\"")
+                                if args.VERBOSE:
+                                    print("├─ Rendered updated \"".decode('utf-8') + outfile + "\"")
                                 # print("Rendered updated " + outfile)
                                 updated_renders += 1
 
                             # If PNG is newer than SVG, leave PNG as is
                             else:
-                                print("├─ \"".decode('utf-8') + outfile + "\" is newer than SVG")
+                                if args.verbose:
+                                    print("├─ \"".decode('utf-8') + outfile + "\" is newer than SVG")
                                 skipped_renders += 1
-                print("├────────────────────────────────┤".decode('utf-8'))
+                if args.verbose:
+                    print("├────────────────────────────────┤".decode('utf-8'))
                 if args.svg is None:
                     print("")
                     print("┌────────────────────────────────┐".decode('utf-8'))
@@ -254,6 +258,8 @@ parser.add_argument('svg', type=str, nargs='?', metavar='SVG',
                     help="Optional SVG names (without extensions) to render. If not given, render all icons")
 parser.add_argument('filter', type=str, nargs='?', metavar='FILTER',
                     help="Optional filter for the SVG file")
+parser.add_argument('--verbose', action='store_true',
+                    help="Print verbose output to the terminal")
 
 args = parser.parse_args()
 

--- a/src/render-apps-categories-bitmaps.py
+++ b/src/render-apps-categories-bitmaps.py
@@ -27,12 +27,10 @@ OPTIPNG = '/usr/bin/optipng'
 MAINDIR = '../usr/share/icons/Mint-Y'
 SOURCES = ['apps', 'categories']
 
-if not os.path.isfile(INKSCAPE):
-    raise Exception("Expected to find Inkscape at /usr/bin/inkscape, but file does not exist.")
-if not os.path.isfile(OPTIPNG):
-    raise Exception("Expected to find OptiPNG at /usr/bin/optipng, but file does not exist.")
-if not os.path.isdir(MAINDIR):
-    raise Exception("Expected to find Mint-Y at ../usr/share/icons/Mint-Y, but directory does not exist.")
+# assert ('linux' in sys.platform), "This code runs on Linux only."
+assert (os.path.isfile(INKSCAPE)), "Expected to find Inkscape at /usr/bin/inkscape, but file does not exist."
+assert (os.path.isfile(OPTIPNG)), "Expected to find OptiPNG at /usr/bin/optipng, but file does not exist."
+assert (os.path.isdir(MAINDIR)), "Expected to find Mint-Y at ../usr/share/icons/Mint-Y, but directory does not exist."
 
 # the resolution that non-hi-dpi icons are rendered at (may be 90 or 96 depending on your inkscape build)
 inkscape_version = str(subprocess.check_output(['inkscape', '-V'])).split(' ')[1].split('.')

--- a/src/render-apps-categories-bitmaps.py
+++ b/src/render-apps-categories-bitmaps.py
@@ -226,6 +226,7 @@ def main(args, SRC):
             print("├─ Rendering from \"".decode('utf-8') + os.path.join(file) + "\"")
             handler = ContentHandler(file, True, filter=args.filter)
             xml.sax.parse(open(file), handler)
+            return True
         else:
             # icon not in this directory, try the next one
             print("├─ Input file \"".decode('utf-8') + file + "\" does not exist.")
@@ -266,25 +267,25 @@ else:
     print("│ Rendering from command-line argument \"".decode('utf-8') + args.svg + "\"")
     print("├────────────────────────────────┤".decode('utf-8'))
 
-success = 0
+success_directory = ""
 
 for source in SOURCES:
     if os.path.exists(os.path.join('.', source)):
         SRC = os.path.join('.', source)
         if main(args, SRC):
-            success += 1
+            success_directory = source
     else:
         print("Source path \"" + os.path.join('.', source) + "\" does not exist.")
 if args.svg is not None:
     print("└────────────────────────────────┘".decode('utf-8'))
 
-if success > 0 and args.svg is not None:
-    print("\nSuccessfully processed \"" + args.svg + "\" in " + source + ".\n")
-elif success == 0 and args.svg is not None:
-    print("\nFailed to process \"" + args.svg + "\" in " + source + ".\n")
-elif success > 0:
+if success_directory != "" and args.svg is not None:
+    print("\nSuccessfully processed \"" + args.svg + "\" in \"" + success_directory + "\".\n")
+elif success_directory == "" and args.svg is not None:
+    print("\nFailed to process \"" + args.svg + "\" in " + success_directory + ".\n")
+elif success_directory != "":
     print("Successfully processed listed sources.\n")
-elif success == 0:
+elif success_directory == "":
     print("Failed to process listed sources.\n")
 else:
     raise Exception("Conditional statement falls through.")

--- a/src/render-apps-categories-bitmaps.py
+++ b/src/render-apps-categories-bitmaps.py
@@ -27,6 +27,13 @@ OPTIPNG = '/usr/bin/optipng'
 MAINDIR = '../usr/share/icons/Mint-Y'
 SOURCES = ['apps', 'categories']
 
+if not os.path.isfile(INKSCAPE):
+    raise Exception("Expected to find Inkscape at /usr/bin/inkscape, but file does not exist.")
+if not os.path.isfile(OPTIPNG):
+    raise Exception("Expected to find OptiPNG at /usr/bin/optipng, but file does not exist.")
+if not os.path.isdir(MAINDIR):
+    raise Exception("Expected to find Mint-Y at ../usr/share/icons/Mint-Y, but directory does not exist.")
+
 # the resolution that non-hi-dpi icons are rendered at (may be 90 or 96 depending on your inkscape build)
 inkscape_version = str(subprocess.check_output(['inkscape', '-V'])).split(' ')[1].split('.')
 inkscape_version = float(inkscape_version[0] + '.' + inkscape_version[1])


### PR DESCRIPTION
Sorry I didn't put these in separate branches—I used the verbose output for debugging as I worked—but this version of `src/render-apps-categories-bitmaps.py` specifically fixes the issue of the script not working with SVG files generated by applications other than Inkscape.

In the updated script, lines 114 to 137 search for all attributes with a given value, rather than searching only for attributes with that value assigned to the Inkscape-specific key `inkscape:label`. If necessary, I could separate out these changes from the verbose output and do two separate merge requests, but honestly the verbose output makes it a lot easier to do testing. (To use verbose output, add `--verbose` to the command.)

I only added verbose output to part of the script, but I could easily expand it to more sections.