### PR TITLE
Simplify parsing to work with non-Inkscape SVGs

### DIFF
--- a/src/render-apps-categories-bitmaps.py
+++ b/src/render-apps-categories-bitmaps.py
@@ -104,29 +104,30 @@ def main(args, SRC):
                     self.inside.append(self.SVG)
                     return
             elif self.inside[-1] == self.SVG:
-                if (name == "g" and ('inkscape:groupmode' in attrs) and ('inkscape:label' in attrs)
-                   and attrs['inkscape:groupmode'] == 'layer' and attrs['inkscape:label'].startswith('Baseplate')):
-                    self.stack.append(self.LAYER)
-                    self.inside.append(self.LAYER)
-                    self.context = None
-                    self.icon_name = None
-                    self.rects = []
-                    return
+                for attr in attrs.values():
+                    if attr == 'Baseplate':
+                        self.stack.append(self.LAYER)
+                        self.inside.append(self.LAYER)
+                        self.context = None
+                        self.icon_name = None
+                        self.rects = []
+                        return
             elif self.inside[-1] == self.LAYER:
-                if name == "text" and ('inkscape:label' in attrs) and attrs['inkscape:label'] == 'context':
-                    self.stack.append(self.TEXT)
-                    self.inside.append(self.TEXT)
-                    self.text='context'
-                    self.chars = ""
-                    return
-                elif name == "text" and ('inkscape:label' in attrs) and attrs['inkscape:label'] == 'icon-name':
-                    self.stack.append(self.TEXT)
-                    self.inside.append(self.TEXT)
-                    self.text='icon-name'
-                    self.chars = ""
-                    return
-                elif name == "rect":
-                    self.rects.append(attrs)
+                for attr in attrs.values():
+                    if attr == "context":
+                        self.stack.append(self.TEXT)
+                        self.inside.append(self.TEXT)
+                        self.text='context'
+                        self.chars = ""
+                        return
+                    if attr == "icon-name":
+                        self.stack.append(self.TEXT)
+                        self.inside.append(self.TEXT)
+                        self.text='icon-name'
+                        self.chars = ""
+                        return
+                    if name == "rect":
+                        self.rects.append(attrs)
 
             self.stack.append(self.OTHER)
 


### PR DESCRIPTION
This version of `src/render-apps-categories-bitmaps.py` specifically fixes the issue of the script not working with SVG files generated by applications other than Inkscape.

In the updated script, the changed lines search for all attributes with a given value, rather than searching only for attributes with that value assigned to the Inkscape-specific key `inkscape:label`.

I separated this out from #284 so you can review it on its own. I tested it both with the existing Firefox icon and with the new one for Joplin.