### PR TITLE
Add symbolic link for .pfx files

### DIFF
--- a/src/symbolic-mimetypes-list
+++ b/src/symbolic-mimetypes-list
@@ -1,4 +1,5 @@
 application-certificate.png <- application-pgp-signature.png
+application-certificate.png <- application-x-pkcs12.png
 application-javascript.png <- application-x-javascript.png
 application-pgp.png <- application-pgp-encrypted.png
 application-sql.png <- application-x-sqlite2.png

--- a/usr/share/icons/Mint-Y/mimetypes/128/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/128/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/128@2x/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/128@2x/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/16/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/16/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/16@2x/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/16@2x/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/24/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/24/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/24@2x/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/24@2x/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/32/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/32/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/32@2x/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/32@2x/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/48/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/48/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/48@2x/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/48@2x/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/64/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/64/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png

--- a/usr/share/icons/Mint-Y/mimetypes/64@2x/application-x-pkcs12.png
+++ b/usr/share/icons/Mint-Y/mimetypes/64@2x/application-x-pkcs12.png
@@ -1,0 +1,1 @@
+application-certificate.png


### PR DESCRIPTION
.pfx files are certificate files in a PKCS#12 format

create a symbolic link to the certificate-mimetype icon