### PR TITLE
RTL icons improvment

### DIFF
--- a/usr/share/icons/Mint-Y/actions/symbolic/go-first-rtl-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/go-first-rtl-symbolic.svg
@@ -1,1 +1,0 @@
-go-last-symbolic.svg

--- a/usr/share/icons/Mint-Y/actions/symbolic/go-last-rtl-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/go-last-rtl-symbolic.svg
@@ -1,1 +1,0 @@
-go-first-symbolic.svg

--- a/usr/share/icons/Mint-Y/actions/symbolic/go-last-symbolic-rtl.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/go-last-symbolic-rtl.svg
@@ -1,1 +1,1 @@
-go-last-symbolic.svg
+go-first-symbolic.svg

--- a/usr/share/icons/Mint-Y/actions/symbolic/go-next-rtl-symbolic.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/go-next-rtl-symbolic.svg
@@ -1,1 +1,0 @@
-go-previous-symbolic.svg

--- a/usr/share/icons/Mint-Y/actions/symbolic/go-previous-symbolic-rtl.svg
+++ b/usr/share/icons/Mint-Y/actions/symbolic/go-previous-symbolic-rtl.svg
@@ -1,0 +1,1 @@
+go-next-symbolic.svg


### PR DESCRIPTION
* Fixed some issues with directional arrow icons (`go-first`, `go-last`, `go-next`, `go-previous`).

I would like to also invert the direction of the speaker volume icons, however they are missing from mint-y and are loaded from Adwaita. I could copy the ltr version from Adwaita and add an inverted rtl version.

Another issue I found is that the `edit-clear` icon for recent documents in `menu@cinnamon.org` applet is not inverted in an rtl layout, despite an rtl icon existing. I'm not sure if that's an icon issue or applet code issue.