### PR TITLE
Symlink vscode icon

### DIFF
--- a/src/symbolic-apps-list
+++ b/src/symbolic-apps-list
@@ -925,6 +925,7 @@ virtman.png <- virt-manager.png
 virtualbox.png <- VBox.png
 virtualbox.png <- virtualbox-ose.png
 visual-studio-code.png <- com.visualstudio.code.png
+visual-studio-code.png <- vscode.png
 vlc.png <- org.videolan.VLC.png
 vmplayer.png <- vmware-player.png
 vmware.png <- vmware-workstation.png


### PR DESCRIPTION
Symlink the vscode icon name to the icon we are using with this theme.