### PR TITLE
Fix broken symbolic links

### DIFF
--- a/src/symbolic-apps-list
+++ b/src/symbolic-apps-list
@@ -398,6 +398,7 @@ gnome-tali.png <- gnubg.png
 gnome-tali.png <- org.gnome.Tali.png
 gnome-tali.png <- tali.png
 gnome-tetravex.png <- org.gnome.tetravex.png
+gnome-tetravex.png <- org.gnome.Tetravex.png
 gnome-todo.png <- org.gnome.Todo.png
 gnome-tweak-tool.png <- org.gnome.tweaks.png
 gnome-weather.png <- com.github.bitseater.weather.png
@@ -1018,7 +1019,6 @@ teamspeak.png <- teamspeak3.png
 teamspeak.png <- ts3client_linux_amd64.png
 terminal.png <- br.app.pw3270.terminal.png
 terminal.png <- io.github.tofudd.lanchat.terminal.png
-tetravex.png <- org.gnome.Tetravex.png
 texmaker.png <- net.xm1math.Texmaker.png
 texstudio.png <- TeXmacs.png
 texstudio.png <- kbibtex.png
@@ -1042,8 +1042,6 @@ trophy.png <- supertuxkart_128.png
 trophy.png <- xmoto.png
 tweetdeck.png <- Tweetdeck-tweetdeck.twitter.com.png
 tweetdeck.png <- chrome-hbdpomandigafcibbmofojjchbcdagbl-Default.png
-uberwriter.png <- Uberwriter.png
-uberwriter.png <- de.wolfvollprecht.UberWriter.png
 ubuntuone.png <- goa-account-ubuntusso.png
 ubuntuone.png <- ubuntuone-client.png
 ubuntuone.png <- ubuntuone-installer.png

--- a/usr/share/icons/Mint-Y/apps/16/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/16/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/16/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/16/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/16/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/16/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/22/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/22/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/22/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/22/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/22/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/22/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/24/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/24/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/24/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/24/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/24/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/24/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/256/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/256/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/256/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/256/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/256/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/256/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/32/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/32/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/32/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/32/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/32/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/32/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/48/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/48/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/48/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/48/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/48/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/48/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/64/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/64/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/64/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/64/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/64/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/64/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/96/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/96/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/96/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/96/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/96/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/96/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/Uberwriter.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/Uberwriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/de.wolfvollprecht.UberWriter.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/de.wolfvollprecht.UberWriter.png
@@ -1,1 +1,0 @@
-uberwriter.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.Tetravex.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.Tetravex.png
@@ -1,1 +1,1 @@
-tetravex.png
+gnome-tetravex.png


### PR DESCRIPTION
Fixes #444 by:

- Replacing an incorrect symbolic link added in 4f979176012633462935013e845bd7f8ebd8f466 for the GNOME Tetravex icon
- Removing the symbolic links for the UberWritter icon, which was removed in 5d62443cc5d06ae493aaa07e70c571333409255e but its symbolic links remained