### PR TITLE
Add link from "org.gnome.Music" to "multimedia-audio-player"

### DIFF
--- a/usr/share/icons/Mint-Y/apps/16/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/16/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/22/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/22/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/24/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/24/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/256/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/256/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/32/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/32/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/48/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/48/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/64/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/64/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/96/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/96/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.Music.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/org.gnome.Music.png
@@ -1,0 +1,1 @@
+multimedia-audio-player.png


### PR DESCRIPTION
I noticed that there is a link for gnome-music to multimedia-audio-player but it wasn't applying correctly to Gnome Music version 46 (the one packaged in Ubuntu 24.04) so I made this PR to fix that.