### PR TITLE
Added symlinks for spotify-launcher and vesktop

### DIFF
--- a/src/symbolic-apps-list
+++ b/src/symbolic-apps-list
@@ -238,6 +238,7 @@ desktop-environment-xfce.png <- xfce4-panel-menu.png
 desktop-environment-xfce.png <- xfce4-panel.png
 desktop-magnifier.png <- kmag.png
 desktop-tweaks.png <- wmtweaks.png
+dev.vencord.Vesktop.png <- vesktop.png
 devhelp.png <- org.gnome.Devhelp.png
 digikam.png <- photolayoutseditor.png
 direct-connect.png <- linuxdcpp.png
@@ -1339,6 +1340,7 @@ web-spotify.png <- chrome-cnkjkdjlofllcpbemipjbcpfnglbgieh-Default.png
 web-spotify.png <- com.spotify.Client.png
 web-spotify.png <- spotify-client.png
 web-spotify.png <- spotify-exe.png
+web-spotify.png <- spotify-launcher.png
 web-spotify.png <- spotify-linux-48x48.png
 web-spotify.png <- spotify.png
 web-teams.png <- Teams-teams.live.com.png

--- a/usr/share/icons/Mint-Y/apps/16/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/16/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/16/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/16/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/16@2x/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/16@2x/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/22/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/22/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/22/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/22/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/22@2x/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/22@2x/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/24/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/24/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/24/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/24/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/24@2x/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/24@2x/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/256/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/256/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/256/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/256/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/256@2x/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/256@2x/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/32/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/32/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/32/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/32/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/32@2x/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/32@2x/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/48/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/48/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/48/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/48/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/48@2x/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/48@2x/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/64/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/64/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/64/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/64/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/64@2x/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/64@2x/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/96/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/96/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/96/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/96/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/spotify-launcher.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/spotify-launcher.png
@@ -1,0 +1,1 @@
+web-spotify.png

--- a/usr/share/icons/Mint-Y/apps/96@2x/vesktop.png
+++ b/usr/share/icons/Mint-Y/apps/96@2x/vesktop.png
@@ -1,0 +1,1 @@
+dev.vencord.Vesktop.png


### PR DESCRIPTION
Solves #497 and Vesktop not using the Mint-Y icon when installing from [their .deb file](https://vesktop.dev/install/linux/#:~:text=deb%20(Debian%20/%20Ubuntu),it%20to%20install.). I can't test spotify-launcher properly because I don't know what package supplies it, but it shows up in the icon select. (I tested this pull request using VirtualBox and the Linux Mint 22.3 Cinnamon installer.)